### PR TITLE
컨트롤러 관심사 분리

### DIFF
--- a/src/main/java/racingcar/Application.java
+++ b/src/main/java/racingcar/Application.java
@@ -1,24 +1,11 @@
 package racingcar;
 
-import racingcar.controller.RacingCarController;
-import racingcar.service.RacingCarService;
-import racingcar.service.ValidateService;
-import racingcar.util.RandomGenerator;
-import racingcar.util.RandomsWrapper;
-import racingcar.view.InstructionView;
-import racingcar.view.ResultView;
-import racingcar.view.RoundView;
+import racingcar.controller.MainController;
 
 public class Application {
     public static void main(String[] args) {
         // TODO: 프로그램 구현
-        InstructionView instructionView = new InstructionView();
-        ValidateService validateService = new ValidateService();
-        RacingCarService racingCarService = new RacingCarService();
-        RoundView roundView = new RoundView();
-        ResultView resultView = new ResultView();
-        RandomGenerator randomGenerator = new RandomsWrapper();
-        RacingCarController controller = new RacingCarController(instructionView, validateService, racingCarService, roundView, resultView, randomGenerator);
-        controller.run();
+        MainController mainController = new MainController();
+        mainController.run();
     }
 }

--- a/src/main/java/racingcar/controller/MainController.java
+++ b/src/main/java/racingcar/controller/MainController.java
@@ -1,0 +1,77 @@
+package racingcar.controller;
+
+import racingcar.domain.RacingCar;
+import racingcar.service.RacingCarService;
+import racingcar.service.ValidateService;
+import racingcar.util.RandomGenerator;
+import racingcar.util.RandomsWrapper;
+import racingcar.view.InstructionView;
+import racingcar.view.ResultView;
+import racingcar.view.RoundView;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+public class MainController {
+
+    private final RacingCarInputController racingCarInputController;
+    private final RacingCarController racingCarController;
+    private final RacingCarOutputController racingCarOutputController;
+    private List<RacingCar> racingCars;
+
+    public MainController() {
+        InstructionView instructionView = new InstructionView();
+        ValidateService validateService = new ValidateService();
+        RacingCarService racingCarService = new RacingCarService();
+        RoundView roundView = new RoundView();
+        ResultView resultView = new ResultView();
+        RandomGenerator randomGenerator = new RandomsWrapper();
+
+        this.racingCarInputController = new RacingCarInputController(instructionView);
+        this.racingCarController = new RacingCarController(validateService, racingCarService, randomGenerator);
+        this.racingCarOutputController = new RacingCarOutputController(roundView, resultView);
+    }
+
+    public void run() {
+        List<String> validatedNames = getValidatedNames();
+        long validatedRaceCount = getValidatedRaceCount();
+        setupRacingCars(validatedNames);
+        runRaceRounds(validatedRaceCount);
+        printRaceResults();
+    }
+
+    // 이름 입력 및 유효성 검증
+    private List<String> getValidatedNames() {
+        String names = racingCarInputController.getRacingCarNames();
+        return racingCarController.validateName(names);
+    }
+
+    // 경주 횟수 입력 및 유효성 검증
+    private long getValidatedRaceCount() {
+        String raceCount = racingCarInputController.getRacingCarRaceCount();
+        return racingCarController.validateRaceCount(raceCount);
+    }
+
+    // 경주 차 초기화
+    private void setupRacingCars(List<String> validatedNames) {
+        this.racingCars = racingCarController.setupRacingCars(validatedNames);
+    }
+
+    // 경주 진행
+    private void runRaceRounds(long validatedRaceCount) {
+        racingCarOutputController.startRaceRound();
+        IntStream.range(0, (int) validatedRaceCount)
+                .forEach(i -> {
+                    racingCarController.runRaceRound(racingCars);
+                    racingCarOutputController.showRaceRound(racingCars);
+                });
+    }
+
+    // 경주 결과 출력
+    private void printRaceResults() {
+        List<RacingCar> bestDrivers = racingCarController.findBestDriver(racingCars);
+        racingCarOutputController.printResult(bestDrivers);
+    }
+
+
+}

--- a/src/main/java/racingcar/controller/RacingCarController.java
+++ b/src/main/java/racingcar/controller/RacingCarController.java
@@ -1,6 +1,5 @@
 package racingcar.controller;
 
-import camp.nextstep.edu.missionutils.Console;
 import racingcar.domain.RacingCar;
 import racingcar.service.RacingCarService;
 import racingcar.service.ValidateService;
@@ -9,46 +8,40 @@ import racingcar.view.InstructionView;
 import racingcar.view.ResultView;
 import racingcar.view.RoundView;
 
+import java.util.List;
 import java.util.stream.IntStream;
 
 
 public class RacingCarController {
 
-    InstructionView instructionView;
     ValidateService validateService;
     RacingCarService racingCarService;
-    RoundView roundView;
-    ResultView resultView;
     RandomGenerator randomGenerator;
 
-    public RacingCarController(InstructionView instructionView, ValidateService validateService, RacingCarService racingCarService, RoundView roundView, ResultView resultView, RandomGenerator randomGenerator) {
-        this.instructionView = instructionView;
+    public RacingCarController(ValidateService validateService, RacingCarService racingCarService, RandomGenerator randomGenerator) {
         this.validateService = validateService;
         this.racingCarService = racingCarService;
-        this.roundView = roundView;
-        this.resultView = resultView;
         this.randomGenerator = randomGenerator;
     }
 
-    public void run() {
-        instructionView.printInstruction("경주할 자동차 이름을 입력하세요.(이름은 쉼표(,) 기준으로 구분)");
-        String names = Console.readLine();
-        validateService.validateName(names);
-        instructionView.printInstruction("시도할 횟수는 몇 회인가요?");
-        String raceCount = Console.readLine();
-        validateService.validateRaceCount(raceCount);
+    public List<RacingCar> setupRacingCars(List<String> validateNames) {
+        return racingCarService.setupRaceCars(validateNames, randomGenerator);
+    }
 
-        racingCarService.setupRaceCars(validateService.getValidatedNames(), randomGenerator);
+    public List<String> validateName(String names) {
+        return validateService.validateName(names);
+    }
 
-        roundView.setRacingCars(racingCarService.getRacingCars());
+    public long validateRaceCount(String raceCount) {
+        return validateService.validateRaceCount(raceCount);
+    }
 
-        IntStream.range(0, (int) validateService.getValidateRaceCount()).forEach(round -> {
-            racingCarService.getRacingCars().forEach(RacingCar::move);
-            roundView.showRoundResults();
-        });
+    public void runRaceRound(List<RacingCar> raceCars) {
+        racingCarService.runRound(raceCars);
+    }
 
-        resultView.printResult(racingCarService.findBestDriver());
-
+    public List<RacingCar> findBestDriver(List<RacingCar> raceCars) {
+        return racingCarService.findBestDriver(raceCars);
     }
 
 }

--- a/src/main/java/racingcar/controller/RacingCarInputController.java
+++ b/src/main/java/racingcar/controller/RacingCarInputController.java
@@ -1,0 +1,23 @@
+package racingcar.controller;
+
+import camp.nextstep.edu.missionutils.Console;
+import racingcar.view.InstructionView;
+
+public class RacingCarInputController {
+
+    InstructionView instructionView;
+
+    public RacingCarInputController(InstructionView instructionView) {
+        this.instructionView = instructionView;
+    }
+
+    public String getRacingCarNames() {
+        instructionView.printInstruction("경주할 자동차 이름을 입력하세요.(이름은 쉼표(,) 기준으로 구분)");
+        return Console.readLine();
+    }
+
+    public String getRacingCarRaceCount() {
+        instructionView.printInstruction("시도할 횟수는 몇 회인가요?");
+        return Console.readLine();
+    }
+}

--- a/src/main/java/racingcar/controller/RacingCarOutputController.java
+++ b/src/main/java/racingcar/controller/RacingCarOutputController.java
@@ -1,0 +1,31 @@
+package racingcar.controller;
+
+import racingcar.domain.RacingCar;
+import racingcar.view.ResultView;
+import racingcar.view.RoundView;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+public class RacingCarOutputController {
+
+    RoundView roundView;
+    ResultView resultView;
+
+    public RacingCarOutputController(RoundView roundView, ResultView resultView) {
+        this.roundView = roundView;
+        this.resultView = resultView;
+    }
+
+    public void startRaceRound() {
+        roundView.startRaceRound();
+    }
+
+    public void showRaceRound(List<RacingCar> racingCars) {
+        roundView.showRoundResults(racingCars);
+    }
+
+    public void printResult(List<RacingCar> bestDriver) {
+        resultView.printResult(bestDriver);
+    }
+}

--- a/src/main/java/racingcar/service/RacingCarService.java
+++ b/src/main/java/racingcar/service/RacingCarService.java
@@ -7,24 +7,15 @@ import java.util.List;
 
 public class RacingCarService {
 
-    List<RacingCar> racingCars;
-
-    public RacingCarService() {
+    public List<RacingCar> setupRaceCars(List<String> racingCarNames, RandomGenerator randomGenerator) {
+        return racingCarNames.stream().map((String name) -> new RacingCar(name, randomGenerator)).toList();
     }
 
-    public void setupRaceCars(List<String> racingCarNames, RandomGenerator randomGenerator) {
-        racingCars = racingCarNames.stream().map((String name) -> new RacingCar(name, randomGenerator)).toList();
-    }
-
-    public void runRound() {
+    public void runRound(List<RacingCar> racingCars) {
         racingCars.forEach(RacingCar::move);
     }
 
-    public List<RacingCar> getRacingCars() {
-        return racingCars;
-    }
-
-    public List<RacingCar> findBestDriver() {
+    public List<RacingCar> findBestDriver(List<RacingCar> racingCars) {
         long maxMoveCount = racingCars.stream()
                 .mapToLong(RacingCar::getMoveCount)
                 .max()

--- a/src/main/java/racingcar/service/ValidateService.java
+++ b/src/main/java/racingcar/service/ValidateService.java
@@ -3,7 +3,6 @@ package racingcar.service;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
 public class ValidateService {
 
@@ -16,7 +15,7 @@ public class ValidateService {
         this.rawNames = new ArrayList<>();
     }
 
-    public void validateName(String names) {
+    public List<String> validateName(String names) {
         rawNames = Arrays.stream(names.split(",")).toList();
 
         rawNames.forEach(rawName -> {
@@ -34,9 +33,10 @@ public class ValidateService {
             // 유효한 이름
             validatedNames.add(trimmedName);
         });
+        return validatedNames;
     }
 
-    public void validateRaceCount(String raceCount) {
+    public long validateRaceCount(String raceCount) {
         String trimmedRaceCount = raceCount.trim();
 
         // 공백 입력
@@ -55,6 +55,7 @@ public class ValidateService {
             // 음수 확인, 숫자로 변경 할 수 없을 경우
             throw new IllegalArgumentException("올바른 숫자를 입력해주세요.");
         }
+        return validateRaceCount;
     }
 
     public long getValidateRaceCount() {

--- a/src/main/java/racingcar/view/RoundView.java
+++ b/src/main/java/racingcar/view/RoundView.java
@@ -6,18 +6,12 @@ import java.util.List;
 
 public class RoundView {
 
-    List<RacingCar> racingCars;
-
-    public RoundView() {
-    }
-
-    public void setRacingCars(List<RacingCar> racingCars) {
+    public void startRaceRound() {
         System.out.println();
         System.out.println("실행 결과");
-        this.racingCars = racingCars;
     }
 
-    public void showRoundResults() {
+    public void showRoundResults(List<RacingCar> racingCars) {
         racingCars.forEach(
                 racingCar -> System.out.println(racingCar.getName() + " : " + "-".repeat((int) racingCar.getMoveCount()))
         );


### PR DESCRIPTION
## 과중된 컨트롤러를 분리함

서비스 흐름에 따라 다음으로 관심사 분리
- RacingCarInputController 
  - 지시문 출력, 입력 등 view 관련 로직
- RacingCarController 
  - RacingCar 객체의 움직임, 이름설정, 유효성 검증 등의 로직
- RacingCarOutputController 
  - 경주 진행 과정 및 결과 출력 view 관련 로직

DI 구조를 사용
- 기존 로직은 service 안에 필드 값으로 RacingCar 를 정의 하도록 함
  - 이 방식은 메서드 간의 결합력을 높여, 코드 유지 보수가 어렵고, 객체지향적이지 못했음
  - 또한, 테스트 코드 작성시, 유닛 테스트가 어렵게 됨을 알 수 있었음
- 최상위 컨트롤러에서, 이 객체를 관리하도록 하고 인자로 넣어 함수가 로직만 실행하도록 구조를 변경함

개선 필요점
-  일급 컬랙션 지정
  - 최상위 컨트롤러에 존재하는, List<RacingCar> 는 DI를 사용하고 있지만 **불변하지 못함**
  - 즉, 다른 곳에서 변경이 일어날 수 있음
  - 이를 방지 하기 위한 **일급 컬랙션 구조** 적용 필요 